### PR TITLE
Refactor: Centralize MDX Components with Index File

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# https://posthog.com/docs/api
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,20 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
+.env.development
+.env.production
+.env.test
+.env.test.local
+.env.test.development
+.env.test.production
+.env.development.local
+.env.production.local
+.env.test.local
+.env.test.development.local
+.env.test.production.local
+
 
 # vercel
 .vercel

--- a/components/mdx/index.ts
+++ b/components/mdx/index.ts
@@ -1,0 +1,35 @@
+import A from "./a";
+import Blockquote from "./blockquote";
+import H1 from "./h1";
+import H2 from "./h2";
+import H3 from "./h3";
+import H4 from "./h4";
+import H5 from "./h5";
+import Code from "./code";
+import Img from "./img";
+import OL from "./ol";
+import P from "./p";
+import Table from "./table";
+import TD from "./td";
+import TH from "./th";
+import TR from "./tr";
+import UL from "./ul";
+
+export const mdxComponents = {
+    h1: H1,
+    h2: H2,
+    h3: H3,
+    h4: H4,
+    h5: H5,
+    p: P,
+    img: Img,
+    blockquote: Blockquote,
+    ul: UL,
+    ol: OL,
+    a: A,
+    table: Table,
+    tr: TR,
+    td: TD,
+    th: TH,
+    code: Code,
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,39 +1,8 @@
-import type { MDXComponents } from 'mdx/types'
-import H1 from '@/components/mdx/h1'
-import H2 from '@/components/mdx/h2'
-import H3 from '@/components/mdx/h3'
-import H4 from '@/components/mdx/h4'
-import H5 from '@/components/mdx/h5'
-import P from '@/components/mdx/p'
-import Img from '@/components/mdx/img'
-import Blockquote from '@/components/mdx/blockquote'
-import UL from '@/components/mdx/ul'
-import OL from '@/components/mdx/ol'
-import A from '@/components/mdx/a'
-import Table from '@/components/mdx/table'
-import TR from '@/components/mdx/tr'
-import TD from '@/components/mdx/td'
-import TH from '@/components/mdx/th'
-import CodeBlock from '@/components/mdx/code'
+import type { MDXComponents } from "mdx/types";
+import { mdxComponents } from "@/components/mdx";
 export function useMDXComponents(components: MDXComponents): MDXComponents {
-
   return {
-    h1: H1,
-    h2: H2,
-    h3: H3,
-    h4: H4,
-    h5: H5,
-    p: P,
-    img: Img,
-    blockquote: Blockquote,
-    ul: UL,
-    ol: OL,
-    a: A,
-    table: Table,
-    tr: TR,
-    td: TD,
-    th: TH,
-    code: CodeBlock,
+    ...mdxComponents,
     ...components,
-  }
+  };
 }


### PR DESCRIPTION
# Refactor MDX Components Organization

## Changes
- Created a central export file (`components/mdx/index.ts`) that exports all MDX components as a single object
- Simplified the `mdx-components.tsx` file by importing the components from the new index file
- Improved maintainability by centralizing the MDX component mappings in one place

## Benefits
- Cleaner code organization with a single source of truth for MDX components
- Easier to add or modify MDX components in the future
- Consistent import structure across the codebase

This refactoring maintains the same functionality while improving code structure.